### PR TITLE
Fixed Chat.js to send current message as a string instead of object

### DIFF
--- a/client/components/Chat.js
+++ b/client/components/Chat.js
@@ -11,7 +11,7 @@ const Chat = () => {
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    room.send('chat', { message: currMessage });
+    room.send('chat', currMessage);
 
     setCurrMessage('');
   };


### PR DESCRIPTION
Changed room.send in onSubmit in Chat.js to send a string instead of object, since this.onMessage for chat event in gameRoom instance is expecting a string.